### PR TITLE
[RFR]: Add event handler to Locked-Disks-RHV service

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -39,3 +39,7 @@ define command{
        command_name     check_vms_distributed_hosts
        command_line     $PLUGINSDIR$/check_rhv_main.py -R $HOSTALIAS$ -u $_HOSTRHVM_LOGIN$ -p $_HOSTRHVM_PASSWORD$ -m vms_distributed_hosts -w $_HOSTRHV_VM_DISTRIBUTION_WARN$ -c $_HOSTRHV_VM_DISTRIBUTION_CRIT$
 }
+define command{
+       command_name     restart_ovirt_engine
+       command_line     $PLUGINSDIR$/eventhandlers/restart-service.py -H $HOSTALIAS$ -S ovirt-engine -s $SERVICESTATE$ -t $SERVICESTATETYPE$ -a $SERVICEATTEMPT$
+}

--- a/pack/services/rhvm_services.cfg
+++ b/pack/services/rhvm_services.cfg
@@ -25,6 +25,7 @@ define service{
    register       0
    host_name	  rhvm
    check_command  check_locked_disks_count
+   event_handler  restart_ovirt_engine
 }
 define service{
    service_description          Hosts-Status


### PR DESCRIPTION
Depends on https://github.com/kedark3/check-rhv/pull/2, which should be merged before this command is merged.

This PR brings in a command `restart_ovirt_engine` that will be used as an event_handler for the `Locked-Disks` check. When this service enters a HARD critical state, the command will restart the `ovirt-engine` using ansible on the remote rhv-manager. This will reset the locked disks on the rhv manager. 